### PR TITLE
fix(backend): set approved flag for new users when approval is disabled

### DIFF
--- a/packages/backend/src/core/SignupService.ts
+++ b/packages/backend/src/core/SignupService.ts
@@ -132,6 +132,8 @@ export class SignupService {
 				token: secret,
 				isRoot: isTheFirstUser,
 				signupReason: opts.reason,
+				// 初回ユーザー（admin）は常に承認済みにする
+				approved: isTheFirstUser ? true : !this.meta.approvalRequiredForSignup,
 			}));
 
 			await transactionalEntityManager.save(new MiUserKeypair({

--- a/packages/backend/src/server/api/SignupApiService.ts
+++ b/packages/backend/src/server/api/SignupApiService.ts
@@ -266,6 +266,9 @@ export class SignupApiService {
 					username, password, host,
 				});
 
+				// ここで承認済みに設定する処理が必要
+				await this.usersRepository.update({ id: account.id }, { approved: true });
+
 				const res = await this.userEntityService.pack(account, account, {
 					schema: 'MeDetailed',
 					includeSecrets: true,


### PR DESCRIPTION
When approval system is disabled, ensure new users are marked as approved immediately after signup. This fixes an issue where users couldn't log in even when approval system was turned off.

- Add approved:true flag in SignupApiService when creating normal accounts
- Keep existing approval logic for initial admin account in SignupService