### PR TITLE
feat: 独自コンポーネントを新しいPaginatorクラスに移行

### DIFF
--- a/packages/frontend/src/components/MkSchedulePostListDialog.vue
+++ b/packages/frontend/src/components/MkSchedulePostListDialog.vue
@@ -6,20 +6,95 @@ SPDX-License-Identifier: AGPL-3.0-only
 <template>
 <MkModalWindow
 	ref="dialogEl"
+	:width="600"
+	:height="650"
 	:withOkButton="false"
 	@click="cancel()"
 	@close="cancel()"
+	@closed="emit('closed')"
+	@esc="cancel()"
 >
-	<template #header>{{ i18n.ts.schedulePostList }}</template>
-	<div class="_gaps_m">
-		<MkPagination ref="paginationEl" :pagination="pagination">
+	<template #header>
+		{{ i18n.ts.schedulePostList }}
+	</template>
+	<div class="_spacer">
+		<MkPagination :paginator="paginator" withControl>
 			<template #empty>
-				<MkResult type="empty"/>
+				<MkResult type="empty" :text="i18n.ts.noNotes"/>
 			</template>
 
 			<template #default="{ items }">
-				<div class="_gaps">
-					<MkNoteSimple v-for="item in items" :key="item.id" :note="item.note" :scheduleId="item.id" @editScheduleNote="listUpdate"/>
+				<div class="_gaps_s">
+					<div
+						v-for="item in items"
+						:key="item.id"
+						v-panel
+						:class="[$style.schedule]"
+					>
+						<div :class="$style.scheduleBody" class="_gaps_s">
+							<div :class="$style.scheduleInfo">
+								<div :class="$style.scheduleMeta">
+									<div v-if="item.note.reply" class="_nowrap">
+										<i class="ti ti-arrow-back-up"></i> <I18n :src="i18n.ts._drafts.replyTo" tag="span">
+											<template #user>
+												<Mfm v-if="item.note.reply.user.name != null" :text="item.note.reply.user.name" :plain="true" :nowrap="true"/>
+												<MkAcct v-else :user="item.note.reply.user"/>
+											</template>
+										</I18n>
+									</div>
+									<div v-if="item.note.renote && item.note.text != null" class="_nowrap">
+										<i class="ti ti-quote"></i> <I18n :src="i18n.ts._drafts.quoteOf" tag="span">
+											<template #user>
+												<Mfm v-if="item.note.renote.user.name != null" :text="item.note.renote.user.name" :plain="true" :nowrap="true"/>
+												<MkAcct v-else :user="item.note.renote.user"/>
+											</template>
+										</I18n>
+									</div>
+									<div v-if="item.note.channel" class="_nowrap">
+										<i class="ti ti-device-tv"></i> {{ i18n.tsx._drafts.postTo({ channel: item.note.channel.name }) }}
+									</div>
+								</div>
+							</div>
+							<div :class="$style.scheduleContent">
+								<Mfm :text="getNoteSummary(item.note, { showRenote: false, showReply: false })" :plain="true"/>
+							</div>
+							<div :class="$style.scheduleFooter">
+								<div :class="$style.scheduleVisibility">
+									<span :title="i18n.ts._visibility[item.note.visibility]">
+										<i v-if="item.note.visibility === 'public'" class="ti ti-world"></i>
+										<i v-else-if="item.note.visibility === 'home'" class="ti ti-home"></i>
+										<i v-else-if="item.note.visibility === 'followers'" class="ti ti-lock"></i>
+										<i v-else-if="item.note.visibility === 'specified'" class="ti ti-mail"></i>
+									</span>
+									<span v-if="item.note.localOnly" :title="i18n.ts._visibility['disableFederation']"><i class="ti ti-rocket-off"></i></span>
+								</div>
+								<div :class="$style.scheduleTime">
+									<i class="ti ti-clock"></i>
+									<MkTime :time="item.scheduledAt" mode="detail" colored/>
+								</div>
+							</div>
+						</div>
+						<div :class="$style.scheduleActions" class="_buttons">
+							<MkButton
+								:class="$style.itemButton"
+								small
+								@click="editSchedule(item)"
+							>
+								<i class="ti ti-corner-up-left"></i>
+								{{ i18n.ts.edit }}
+							</MkButton>
+							<MkButton
+								v-tooltip="i18n.ts.delete"
+								danger
+								small
+								:iconOnly="true"
+								:class="$style.itemButton"
+								@click="deleteSchedule(item)"
+							>
+								<i class="ti ti-trash"></i>
+							</MkButton>
+						</div>
+					</div>
 				</div>
 			</template>
 		</MkPagination>
@@ -28,32 +103,118 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import type { Paging } from '@/components/MkPagination.vue';
-import MkModalWindow from '@/components/MkModalWindow.vue';
+import { ref, shallowRef, markRaw } from 'vue';
+import * as Misskey from 'misskey-js';
+import MkButton from '@/components/MkButton.vue';
 import MkPagination from '@/components/MkPagination.vue';
-import MkNoteSimple from '@/components/MkNoteSimple.vue';
+import MkModalWindow from '@/components/MkModalWindow.vue';
 import MkResult from '@/components/global/MkResult.vue';
+import MkTime from '@/components/global/MkTime.vue';
+import MkAcct from '@/components/global/MkAcct.vue';
+import I18n from '@/components/global/I18n.vue';
+import { getNoteSummary } from '@/utility/get-note-summary.js';
 import { i18n } from '@/i18n.js';
+import * as os from '@/os.js';
+import { Paginator } from '@/utility/paginator.js';
 
 const emit = defineEmits<{
 	(ev: 'cancel'): void;
+	(ev: 'closed'): void;
+	(ev: 'editScheduleNote', scheduleId: string): void;
 }>();
 
-const dialogEl = ref();
-const cancel = () => {
-	emit('cancel');
-	dialogEl.value.close();
-};
+const dialogEl = shallowRef<InstanceType<typeof MkModalWindow>>();
 
-const paginationEl = ref();
-const pagination: Paging = {
-	endpoint: 'notes/schedule/list',
+const paginator = markRaw(new Paginator('notes/schedule/list', {
 	limit: 10,
-	noPaging: true, // offsetMode: true から変更
-};
+}));
 
-function listUpdate() {
-	paginationEl.value.reload();
+function cancel() {
+	emit('cancel');
+	dialogEl.value?.close();
+}
+
+function editSchedule(item: any) {
+	emit('editScheduleNote', item.id);
+	dialogEl.value?.close();
+}
+
+async function deleteSchedule(item: any) {
+	const { canceled } = await os.confirm({
+		type: 'warning',
+		text: i18n.ts.deleteConfirm,
+	});
+
+	if (canceled) return;
+
+	os.apiWithDialog('notes/schedule/delete', {
+		noteId: item.note.id,
+	}).then(() => {
+		paginator.reload();
+	});
 }
 </script>
+
+<style lang="scss" module>
+.schedule {
+    padding: 16px;
+    gap: 16px;
+    border-radius: 10px;
+}
+
+.scheduleBody {
+    width: 100%;
+    min-width: 0;
+}
+
+.scheduleInfo {
+    display: flex;
+    width: 100%;
+    font-size: 0.85em;
+    opacity: 0.7;
+}
+
+.scheduleMeta {
+    flex-grow: 1;
+    min-width: 0;
+}
+
+.scheduleContent {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    font-size: 0.9em;
+}
+
+.scheduleFooter {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.scheduleVisibility {
+    flex-shrink: 0;
+}
+
+.scheduleTime {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 85%;
+    color: var(--MI_THEME-accent);
+    font-weight: 600;
+}
+
+.scheduleActions {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: solid 1px var(--MI_THEME-divider);
+}
+
+.itemButton {
+    min-width: auto;
+}
+</style>

--- a/packages/frontend/src/pages/admin/approvals.vue
+++ b/packages/frontend/src/pages/admin/approvals.vue
@@ -9,10 +9,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<template #header><MkPageHeader :actions="headerActions" :tabs="headerTabs"/></template>
 		<div class="_spacer" style="--MI_SPACER-w: 900px;">
 			<div class="_gaps_m">
-				<MkPagination ref="paginationComponent" :pagination="pagination">
+				<MkPagination :paginator="paginator">
 					<template #default="{ items }">
 						<div class="_gaps_s">
-							<MkApprovalUser v-for="item in items" :key="item.id" :user="item" :onDeleted="deleted"/>
+							<MkApprovalUser v-for="user in items" :key="user.id" :user="user" @deleted="deleted"/>
 						</div>
 					</template>
 				</MkPagination>
@@ -23,30 +23,26 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { computed, shallowRef } from 'vue';
+import { computed, markRaw } from 'vue';
 import MkPageHeader from '@/components/global/MkPageHeader.vue';
 import MkPagination from '@/components/MkPagination.vue';
 import MkApprovalUser from '@/components/MkApprovalUser.vue';
 import { i18n } from '@/i18n.js';
 import { definePage } from '@/page.js';
+import { Paginator } from '@/utility/paginator.js';
 
-let paginationComponent = shallowRef<InstanceType<typeof MkPagination>>();
-
-const pagination = {
-	endpoint: 'admin/show-users' as const,
+const paginator = markRaw(new Paginator('admin/show-users', {
 	limit: 10,
-	params: computed(() => ({
+	computedParams: computed(() => ({
 		sort: '+createdAt',
 		state: 'pending',
 		origin: 'local',
 	})),
-	noPaging: true,
-};
+	offsetMode: true,
+}));
 
 function deleted(id: string) {
-	if (paginationComponent.value) {
-		paginationComponent.value.paginator.removeItem(id);
-	}
+	paginator.removeItem(id);
 }
 
 const headerActions = computed(() => []);

--- a/packages/frontend/src/pages/channel/followers-list.vue
+++ b/packages/frontend/src/pages/channel/followers-list.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div>
-	<MkPagination v-slot="{items}" ref="list" :pagination="followersPagination">
+	<MkPagination v-slot="{items}" :paginator="followersPaginator" withControl>
 		<div :class="$style.users">
 			<MkUserInfo v-for="user in items.map(x => x.follower)" :key="user.id" :user="user"/>
 		</div>
@@ -14,29 +14,28 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
+import { computed, markRaw } from 'vue';
 import * as Misskey from 'misskey-js';
 import MkUserInfo from '@/components/MkUserInfo.vue';
 import MkPagination from '@/components/MkPagination.vue';
+import { Paginator } from '@/utility/paginator.js';
 
 const props = defineProps<{
 	channelId: string;
 }>();
 
-const followersPagination = {
-	endpoint: 'channels/followers' as const,
+const followersPaginator = markRaw(new Paginator('channels/followers', {
 	limit: 20,
-	params: computed(() => ({
+	computedParams: computed(() => ({
 		channelId: props.channelId,
 	})),
-};
+}));
 </script>
 
 <style lang="scss" module>
 .users {
     display: grid;
-    /* auto-fillを使いつつ、標準的なユーザーカード幅を使用 */
-    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
     grid-gap: var(--MI-margin);
 }
 </style>


### PR DESCRIPTION
- MkSchedulePostListDialog: 下書きリストダイアログを参考に全面刷新
  - カード形式のUIで予約時間と可視性を表示
  - 削除・編集機能を統合し、UXを向上
- 管理者承認ページ: 招待コードページを参考にoffsetModeを使用
  - computedParamsでリアクティブなパラメータ処理
  - 重複表示問題を解決
- チャンネルフォロワー一覧: ユーザーフォロワーページと同等の実装
  - withControlでソート機能を追加
  - computedParamsで動的パラメータに対応

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
独自コンポーネントを新しいPaginatorクラスに移行


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
- 予約投稿一覧が表示されない
- チャンネルのフォロワータブが表示されない
- 承認待ちユーザーが表示されない

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
