### PR TITLE
fix(migration): Fix production startup failure due to NULL values in user_pending.reason

### DIFF
--- a/packages/backend/migration/1761962604922-fix-schema-sync.js
+++ b/packages/backend/migration/1761962604922-fix-schema-sync.js
@@ -18,6 +18,7 @@
         await queryRunner.query(`ALTER TABLE "reversi_game" DROP COLUMN "federationId"`);
         await queryRunner.query(`ALTER TABLE "reversi_game" ADD "federationId" character varying(36)`);
         await queryRunner.query(`COMMENT ON COLUMN "role"."isCommunity" IS 'Whether this role was created by community users (not admins)'`);
+        await queryRunner.query(`UPDATE "user_pending" SET "reason" = '' WHERE "reason" IS NULL`);
         await queryRunner.query(`ALTER TABLE "user_pending" ALTER COLUMN "reason" SET NOT NULL`);
     }
     async down(queryRunner) {


### PR DESCRIPTION
## 問題

タグ付けされたDockerイメージで本番環境を起動した際、マイグレーションエラーにより起動に失敗しました。

The tagged Docker image failed to start in production environment due to a migration error.

## エラー内容
```log
ERROR: 23502: column "reason" of relation "user_pending" contains null values Migration "FixSchemaSync1761962604922" failed, error: column "reason" of relation "user_pending" contains null values
```
マイグレーション `FixSchemaSync1761962604922` において、`user_pending` テーブルの `reason` カラムに NOT NULL 制約を設定しようとしましたが、既存のデータベースに NULL 値を持つレコードが存在していたため失敗しました。

## 原因

マイグレーションが以下の処理を行っていました：
```javascript
await queryRunner.query(`ALTER TABLE "user_pending" ALTER COLUMN "reason" SET NOT NULL`);
```
しかし、既存のデータベースに reason カラムが NULL のレコードが存在する場合、NOT NULL 制約を適用できないため、PostgreSQL がエラーを返していました。
修正内容 / Fix
NOT NULL 制約を適用する前に、NULL 値を空文字列に更新する処理を追加しました：
```javascript
await queryRunner.query(`UPDATE "user_pending" SET "reason" = '' WHERE "reason" IS NULL`);
await queryRunner.query(`ALTER TABLE "user_pending" ALTER COLUMN "reason" SET NOT NULL`);
```
これにより、既存のデータベースでもマイグレーションが正常に完了するようになります。

## 影響範囲
新規インストール: 影響なし（user_pending に NULL レコードが存在しないため）
既存環境からのアップグレード: この修正により正常にマイグレーションが完了するようになります

## テスト
 - [ ] NULL 値を持つ user_pending レコードが存在する環境でマイグレーションが成功することを確認
 - [ ] Docker イメージからの起動が正常に完了することを確認