### PR TITLE
fix(ci): use App token in release-on-merge to bypass tag-protection

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -22,9 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'Release:'))
     steps:
+      # tag-protection ruleset の bypass list に登録された App のトークンを使う
+      - uses: actions/create-github-app-token@v1
+        id: release-app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Get current version
         id: version
@@ -155,7 +162,7 @@ jobs:
             --target master \
             --latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       - name: Summary
         if: steps.version.outputs.should_create_release == 'true' && steps.tag_check.outputs.tag_exists == 'false'


### PR DESCRIPTION
## Summary

- `release-on-merge.yml` が default `GITHUB_TOKEN` で checkout していたため、`git push origin <tag>` が `github-actions[bot]` として実行され、bypass 対象外となり `tag-protection` ruleset で拒否されていた
- App token (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) を使うよう修正
- `actions/create-github-app-token` を最初に配置し、`checkout` の `token` と `gh release create` の `GITHUB_TOKEN` に渡す

## Background

`release-manager-actions` の `create-target.yml` / `merge.yml` は修正済み（v2-yamisskey）。残るのは yamisskey 本体の `release-on-merge.yml` のみで、これを修正することで master merge 時のタグ作成・Release 作成が bypass list 経由で通るようになる。

## Test plan
- [ ] develop → staging → master にマージ後、Release Manager [Dispatch] を実行
- [ ] release-on-merge ワークフローが tag を push できることを確認
- [ ] GitHub Release が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)