### PR TITLE
Release: promote staging to master (release-on-merge app token fix)

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -22,9 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'Release:'))
     steps:
+      # tag-protection ruleset の bypass list に登録された App のトークンを使う
+      - uses: actions/create-github-app-token@v1
+        id: release-app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.release-app-token.outputs.token }}
 
       - name: Get current version
         id: version
@@ -155,7 +162,7 @@ jobs:
             --target master \
             --latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-app-token.outputs.token }}
 
       - name: Summary
         if: steps.version.outputs.should_create_release == 'true' && steps.tag_check.outputs.tag_exists == 'false'


### PR DESCRIPTION
## Summary

- staging をマージして `release-on-merge.yml` の App token 対応を master に反映
- このマージによって master 側の release-on-merge ワークフローが新仕様（App token）で動作するようになる

参照: #273, #274

## Note

タイトルに `Release:` を入れているため、マージ後に `release-on-merge.yml` が発火してタグ作成・GitHub Release が行われる想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CDワークフローの認証メカニズムを更新しました。

**注記：** このリリースはインフラストラクチャの改善であり、ユーザーに対する機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->