### PR TITLE
fix(floater): 初浮上判定の誤検知を解消 (#218)

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/floater.ts
+++ b/packages/backend/src/server/api/endpoints/notes/floater.ts
@@ -163,14 +163,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
                         ORDER BY "id" DESC
                         LIMIT 1
                     ) AS last_post_id,
-                    -- 初浮上かどうかを判定する部分を追加
+                    -- 初浮上: anchor 以前に当該ユーザーのノートが 1 つも存在しないこと
+                    -- (リプライ/リノート/home/followers/specified も "過去の活動" と見なす。
+                    --  visibility=public かつ renoteId/replyId IS NULL に限ると、
+                    --  リプライや home のみ投稿してきた既存ユーザーが誤って初浮上判定されてしまう)
                     NOT EXISTS (
                         SELECT 1 FROM "note"
                         WHERE "userId" = lau."userId"
                             AND "id" < $2
-                            AND "visibility" IN ('public')
-                            AND "renoteId" IS NULL
-                            AND "replyId" IS NULL
                             AND ("isNoteInYamiMode" = FALSE OR $5 = TRUE)
                     ) AS is_first_public_post,
                     -- フォロー状態 (userFollowingsCache から受け取った配列で判定)


### PR DESCRIPTION
Fixes #218

## Summary

浮上タイムラインの「初浮上」判定 (`is_first_public_post`) が誤検知を起こしており、実際には以前から活動していたユーザーが「初浮上」として強調表示されてしまう不具合を修正する。

## 原因

[packages/backend/src/server/api/endpoints/notes/floater.ts](packages/backend/src/server/api/endpoints/notes/floater.ts) の CTE `user_last_posts` 内 `is_first_public_post` サブクエリの EXISTS 条件が **スタンドアロンのパブリックノート** に限定されていた:

\`\`\`sql
NOT EXISTS (
    SELECT 1 FROM \"note\"
    WHERE \"userId\" = lau.\"userId\"
        AND \"id\" < \$2
        AND \"visibility\" IN ('public')   -- ← home/followers/specified を無視
        AND \"renoteId\" IS NULL           -- ← リノートを無視
        AND \"replyId\" IS NULL            -- ← リプライを無視
        AND (\"isNoteInYamiMode\" = FALSE OR \$5 = TRUE)
) AS is_first_public_post
\`\`\`

このため以下のような既存ユーザーが誤って初浮上として検出されていた:

- 過去はリプライ/リノートのみで活動していたユーザー
- 過去は home/followers/specified の投稿のみで活動していたユーザー

浮上タイムライン自体はスタンドアロンのパブリックノートしか表示しないため「floater 的な初登場」という意味では一理あるが、UI 上は「初浮上」としてアクセント色で強調されるため、閲覧者から見ると「以前から見かけていたアカウントなのに」という違和感を生んでいた。

## 修正

EXISTS 条件から \`visibility = 'public'\` と \`renoteId/replyId IS NULL\` を撤去し、「anchor 以前に当該ユーザーのノートが 1 件でも存在すれば初浮上ではない」という最も厳格な判定に寄せる。やみモードのフィルタ (\`isNoteInYamiMode\` / \`me.isInYamiMode\`) は維持 — やみモード OFF の閲覧者視点で、過去がやみノートのみのユーザーは依然「初めて見える」に等しいため。

### 変更前後の比較

| ユーザー状況 | 旧判定 | 新判定 |
|---|---|---|
| 過去の note 0 件 | 初浮上 | 初浮上 (変わらず) |
| 過去はリプライのみ | 初浮上 ❌ | 通常 ✅ |
| 過去はリノートのみ | 初浮上 ❌ | 通常 ✅ |
| 過去は home のみ | 初浮上 ❌ | 通常 ✅ |
| 過去に public あり | 通常 | 通常 (変わらず) |
| やみのみ (閲覧者非やみ) | 初浮上 | 初浮上 (変わらず) |

## Test plan

- [x] \`pnpm --filter backend run typecheck\`
- [x] \`pnpm --filter backend exec eslint\` on floater.ts
- [ ] dev 環境で以下を手動確認:
  - [ ] 過去にリプライのみのユーザーが初スタンドアロン投稿をしても \"初浮上\" にならない
  - [ ] 真の新規ユーザーは \"初浮上\" として表示される
  - [ ] やみモード OFF の閲覧者に対し、過去がやみノートのみのユーザーは依然 \"初浮上\" と表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)