### PR TITLE
Revert "fix(floater): 初浮上判定の誤検知を解消 (#218)"

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/floater.ts
+++ b/packages/backend/src/server/api/endpoints/notes/floater.ts
@@ -163,14 +163,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
                         ORDER BY "id" DESC
                         LIMIT 1
                     ) AS last_post_id,
-                    -- 初浮上: anchor 以前に当該ユーザーのノートが 1 つも存在しないこと
-                    -- (リプライ/リノート/home/followers/specified も "過去の活動" と見なす。
-                    --  visibility=public かつ renoteId/replyId IS NULL に限ると、
-                    --  リプライや home のみ投稿してきた既存ユーザーが誤って初浮上判定されてしまう)
+                    -- 初浮上かどうかを判定する部分を追加
                     NOT EXISTS (
                         SELECT 1 FROM "note"
                         WHERE "userId" = lau."userId"
                             AND "id" < $2
+                            AND "visibility" IN ('public')
+                            AND "renoteId" IS NULL
+                            AND "replyId" IS NULL
                             AND ("isNoteInYamiMode" = FALSE OR $5 = TRUE)
                     ) AS is_first_public_post,
                     -- フォロー状態 (userFollowingsCache から受け取った配列で判定)


### PR DESCRIPTION
PR #284 の revert。

## 理由

#284 では「初浮上」判定の false positive を解消するつもりで `is_first_public_post` の EXISTS 条件から `visibility = 'public'` / `renoteId IS NULL` / `replyId IS NULL` を撤去した。しかし yamisskey における「浮上」の語義を取り違えていた。

### 「浮上」の正しい定義

- **浮上** = LTL (Local Timeline) にパブリックなスタンドアロン投稿で現れること
- **初浮上** = アカウントの初活動ではなく、**そのユーザーが LTL に現れた最初の機会**

したがって以下のユーザーが「初浮上」として検出されるのは正しい挙動:

- 過去にリプライ/リノートのみで活動していたユーザー (= LTL には現れていない) の初スタンドアロンパブリック投稿
- 過去に home/followers/specified の投稿のみだったユーザー (= LTL には現れていない) の初パブリック投稿

元の EXISTS 条件 (`visibility='public'` かつ `renoteId/replyId IS NULL`) こそが LTL の表示条件と一致しており、「初浮上」判定として妥当。

## #218 の扱い

`fixes #218` が含まれていたが、誤認による close だったので再 open してください。真因は別にあると思われる (削除済みノート、federation の edge case、ID 生成の境界条件など) ため追加調査が必要。

## Test plan

- [x] `pnpm --filter backend run typecheck`
- [x] revert 結果が merge commit 直前 (5453a70fd4) と同一であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)