### PR TITLE
Release: 2026.3.2-yami-1.9.37 (floater hotfix)

### DIFF
--- a/DIFFERENCE.md
+++ b/DIFFERENCE.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2026.3.2-yami-1.9.36
+
 ### Refactor
 - **浮上タイムラインを本家 LTL と同等のフィルタ機構に整合 (#283)**
   - `meta.res` を実レスポンス形状 (`{id, notes, last, isFirstPublicPost, isFollowing}[]`) に修正。従来は `Note[]` と宣言しており frontend での `any` キャスト残存の原因になっていた

--- a/DIFFERENCE.md
+++ b/DIFFERENCE.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 2026.3.2-yami-1.9.37
+
+### Fix
+- **浮上タイムラインの 500 エラーを修正**
+  - 1.9.36 で `generateBaseNoteFilteringQuery` を導入した際、この関数が内部で呼ぶ `generateSuspendedUserQueryForNote` が要求する `replyUser` / `renoteUser` エイリアスの LEFT JOIN を張り忘れており、`POST /api/notes/floater` が 500 を返していた
+  - `note.reply` / `note.renote` / `reply.user` / `renote.user` の LEFT JOIN を追加して解消 (local-timeline と同じチェーン)
+- **浮上タイムラインの dev ビルド console 警告を解消**
+  - 手書きの `formatFloaterMessage()` が `i18n.ts._floater[key]` を経由してプレースホルダ付き文字列を取得しており、dev モードの Proxy が `Missing locale parameters: date, user at userFirstPublicPost` を warn していた
+  - `i18n.tsx._floater.xxx({user, date, n})` の型付き API に各呼出を切り替えてヘルパーを削除
+
 ## 2026.3.2-yami-1.9.36
 
 ### Refactor

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.3.2-yami-1.9.36",
+	"version": "2026.3.2-yami-1.9.37",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.3.2-yami-1.9.35",
+	"version": "2026.3.2-yami-1.9.36",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/backend/src/server/api/endpoints/notes/floater.ts
+++ b/packages/backend/src/server/api/endpoints/notes/floater.ts
@@ -195,7 +195,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 		return await Promise.all(updatedUsers.map(async (row: { user: string; last: string | null; is_following: boolean; is_first_public_post: boolean }) => {
 			const userId = row.user;
-			const query = this.notesRepository.createQueryBuilder('note').innerJoinAndSelect('note.user', 'user');
+			// generateBaseNoteFilteringQuery が replyUser/renoteUser エイリアスを要求するため
+			// local-timeline と同じ LEFT JOIN チェーンを張る
+			const query = this.notesRepository.createQueryBuilder('note')
+				.innerJoinAndSelect('note.user', 'user')
+				.leftJoinAndSelect('note.reply', 'reply')
+				.leftJoinAndSelect('note.renote', 'renote')
+				.leftJoinAndSelect('reply.user', 'replyUser')
+				.leftJoinAndSelect('renote.user', 'renoteUser');
 
 			// 標準の可視性クエリ
 			this.queryService.generateVisibilityQuery(query, me);

--- a/packages/frontend/src/pages/floater/floater.vue
+++ b/packages/frontend/src/pages/floater/floater.vue
@@ -177,19 +177,6 @@ function getCompareNote(note: FloaterNote, index: number, item: FloaterItem): Fl
 
 // ----- i18n / ユーザー名 -----
 
-function formatFloaterMessage(messageKey: string, params: Record<string, string>): string {
-	const messageTemplate = (i18n.ts._floater as Record<string, string | undefined>)[messageKey];
-	if (!messageTemplate) {
-		console.warn(`Missing floater message: ${messageKey}`);
-		return messageKey;
-	}
-	let message = messageTemplate;
-	for (const [key, value] of Object.entries(params)) {
-		message = message.replaceAll(`{${key}}`, value);
-	}
-	return message;
-}
-
 function formatUserName(user: FloaterNote['user']): string {
 	return (user.name ?? user.username).replace(/:([\w-]+):/g, '').trim();
 }
@@ -239,7 +226,7 @@ function getCombinedFloaterInfo(item: FloaterItem, noteIndex = 0, nextNote?: Flo
 
 	// 初浮上
 	if (item.isFirstPublicPost && isOldestNote(currentNote, item)) {
-		const result = formatFloaterMessage('userFirstPublicPost', {
+		const result = i18n.tsx._floater.userFirstPublicPost({
 			user: formatUserName(currentNote.user),
 			date: getDisplayDateString(currentNote.createdAt),
 		});
@@ -263,7 +250,7 @@ function getCombinedFloaterInfo(item: FloaterItem, noteIndex = 0, nextNote?: Flo
 
 	const compareNote = nextNote ?? getCompareNote(currentNote, noteIndex, item);
 	if (!compareNote) {
-		return formatFloaterMessage('userRarelyAppeared', {
+		return i18n.tsx._floater.userRarelyAppeared({
 			user: formatUserName(currentNote.user),
 			date: getDisplayDateString(currentDate),
 		});
@@ -278,10 +265,10 @@ function getCombinedFloaterInfo(item: FloaterItem, noteIndex = 0, nextNote?: Flo
 	const diffDays = getNoteDaysDifference(currentNote, compareNote);
 	if (diffDays === 0) return getDateText(currentDate);
 
-	const result = formatFloaterMessage('userAfterNDays', {
+	const result = i18n.tsx._floater.userAfterNDays({
 		user: formatUserName(currentNote.user),
 		date: getDisplayDateString(currentDate),
-		n: diffDays.toString(),
+		n: diffDays,
 	});
 	if (isNewestNote(currentNote, item)) cache.info = result;
 	return result;
@@ -289,7 +276,7 @@ function getCombinedFloaterInfo(item: FloaterItem, noteIndex = 0, nextNote?: Flo
 
 function getDateInfo(note: FloaterNote, index: number, item: FloaterItem): string {
 	if (item.isFirstPublicPost && isOldestNote(note, item)) {
-		return formatFloaterMessage('userFirstPublicPost', {
+		return i18n.tsx._floater.userFirstPublicPost({
 			user: formatUserName(note.user),
 			date: getDisplayDateString(note.createdAt),
 		});
@@ -299,10 +286,10 @@ function getDateInfo(note: FloaterNote, index: number, item: FloaterItem): strin
 		const compareNote = getCompareNote(note, index, item);
 		const diffDays = getNoteDaysDifference(note, compareNote);
 		if (diffDays > 0) {
-			return formatFloaterMessage('userAfterNDays', {
+			return i18n.tsx._floater.userAfterNDays({
 				user: formatUserName(note.user),
 				date: getDisplayDateString(note.createdAt),
-				n: diffDays.toString(),
+				n: diffDays,
 			});
 		}
 	}

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2026.3.2-yami-1.9.36",
+	"version": "2026.3.2-yami-1.9.37",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2026.3.2-yami-1.9.35",
+	"version": "2026.3.2-yami-1.9.36",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",


### PR DESCRIPTION
## Summary

1.9.36 リリース後に発覚した浮上タイムラインの回帰 2 件を修正する hotfix リリース。

### Fix
- **浮上タイムラインの 500 エラーを修正** (\`785974695b\`)
  - 1.9.36 で \`generateBaseNoteFilteringQuery\` を導入した際、この関数が内部で呼ぶ \`generateSuspendedUserQueryForNote\` が要求する \`replyUser\` / \`renoteUser\` エイリアスの LEFT JOIN を張り忘れていた
  - \`QueryService.ts:364\` のコメント \`// Requirements: user replyUser renoteUser must be joined\` の通りの前提を満たしていなかった
  - \`note.reply\` / \`note.renote\` / \`reply.user\` / \`renote.user\` の LEFT JOIN を追加して解消 (local-timeline と同じチェーン)
- **dev ビルドの i18n console 警告を解消** (\`c8c266ba9a\`)
  - 手書きの \`formatFloaterMessage()\` が \`i18n.ts._floater[key]\` 経由でプレースホルダ付き文字列を取得しており、dev モードの Proxy が \`Missing locale parameters: date, user at userFirstPublicPost\` を warn していた
  - \`i18n.tsx._floater.xxx({user, date, n})\` の型付き API に各呼出を切り替えヘルパー撤去 (-13 行)

## Why hotfix

PR #287 (Release: 1.9.36) は \`fc7b76ade3\` (version bump commit) を head としてマージされたが、その後に develop へ push した上記 2 つの fix commit はリリースに含まれなかった。結果として 1.9.36 本番では \`/api/notes/floater\` が 500 を返す状態になっている。

## Test plan

- [x] backend typecheck / eslint クリーン
- [x] frontend typecheck / eslint クリーン
- [x] ユーザーの devcontainer 環境で 500 解消・i18n 警告消失を確認済み
- [ ] マージ後に \`release-on-merge.yml\` が正常起動し 2026.3.2-yami-1.9.37 タグ生成
- [ ] 本番環境で \`/api/notes/floater\` が 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)