### PR TITLE
Release: 2026.3.2-yami-1.9.38

### DIFF
--- a/DIFFERENCE.md
+++ b/DIFFERENCE.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 2026.3.2-yami-1.9.38
+
+### Fix
+- **Service Worker の空通知がクローズされず積み上がる問題を修正 (#291, #292)**
+  - `createEmptyNotification` で `showNotification` 時に `tag: 'read_notification'` を設定しているが、1秒後のクローズ呼び出しで別タグ `'user_visible_auto_notification'` が指定されており、空通知が閉じられず通知ドロワーに残り続けていた
+  - iOS Safari PWA や一部 Android 環境では同タグ置換が不完全なため、`readAllNotifications` push などを契機に `yami.ski / Misskey v...` という空通知が複数並ぶ現象が発生していた
+  - 本家 `misskey-dev/misskey` PR #7667 の原設計（`'read_notification'` と `'user_visible_auto_notification'` の両方をクローズ対象とする）に戻す形で修正。`'user_visible_auto_notification'` は Chromium が silent push フォールバック時に内部付与するタグで、Misskey 側が set しているものではない
+  - 本家 PR #10570 で `'read_notification'` が配列から欠落したリグレッションの修正。upstream にも別途還元予定
+
 ## 2026.3.2-yami-1.9.37
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.3.2-yami-1.9.37",
+	"version": "2026.3.2-yami-1.9.38",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2026.3.2-yami-1.9.37",
+	"version": "2026.3.2-yami-1.9.38",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -364,7 +364,9 @@ export async function createEmptyNotification(): Promise<void> {
 	return new Promise<void>(res => {
 		setTimeout(async () => {
 			try {
-				await closeNotificationsByTags(['read_notification']);
+				// 'user_visible_auto_notification' は Chromium が silent push フォールバック時に
+				// 自動付与するタグ（Misskey 側では set していない）。同時に掃除する。
+				await closeNotificationsByTags(['read_notification', 'user_visible_auto_notification']);
 			} finally {
 				res();
 			}

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -364,7 +364,7 @@ export async function createEmptyNotification(): Promise<void> {
 	return new Promise<void>(res => {
 		setTimeout(async () => {
 			try {
-				await closeNotificationsByTags(['user_visible_auto_notification']);
+				await closeNotificationsByTags(['read_notification']);
 			} finally {
 				res();
 			}


### PR DESCRIPTION
## Summary
Service Worker の空通知クローズ不整合 (#291, #292) を修正する hotfix リリース。

### 含まれる変更

- **fix(sw): Service Worker の空通知がクローズされず積み上がる問題を修正** (#291, #292)
  - `createEmptyNotification` で `showNotification({ tag: 'read_notification' })` と `closeNotificationsByTags(['user_visible_auto_notification'])` のタグ名が不一致で、空通知が閉じられず通知ドロワーに積み上がっていた
  - 本家 `misskey-dev/misskey` PR #7667 の原設計に戻す形で両タグをクローズ対象に復元
  - 本家 PR #10570 で `'read_notification'` が配列から欠落したリグレッションの修正

詳細は [DIFFERENCE.md](https://github.com/yamisskey-dev/yamisskey/blob/develop/DIFFERENCE.md) の `2026.3.2-yami-1.9.38` セクション参照。

## 検証観点

- [ ] staging 環境デプロイ後、push 通知の通常経路（`notification` / `unreadAntennaNote` / `newChatMessage`）が従来通り表示される
- [ ] 他端末で通知を既読にした際、対象端末の通知ドロワーに空通知が積み上がらない
- [ ] 1日以上前の `notification` type push を受信した際も空通知が積み上がらない
- [ ] SW の更新タイミングに注意: `skipWaiting()` は入っていないため、iOS PWA では一度アプリを完全終了して再起動が必要

## 本家 upstream 還元

本家 misskey-dev/misskey の現 master にも同一バグ（PR #10570 リグレッション）が存在。本リリースで動作確認取得後、本家にも Issue + PR を別途提出予定。

Closes #291 (via PR #292 develop merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)