### PR TITLE
docs(DIFFERENCE): dedup 1.9.38 heading and restore Unreleased

### DIFF
--- a/DIFFERENCE.md
+++ b/DIFFERENCE.md
@@ -1,6 +1,6 @@
 # DIFFRENCE
 
-## 2026.3.2-yami-1.9.38
+## Unreleased
 
 ## 2026.3.2-yami-1.9.38
 


### PR DESCRIPTION
## Summary
Release Manager の自動 bump と develop 側の明示見出しが衝突し、staging / master の DIFFERENCE.md に \`## 2026.3.2-yami-1.9.38\` が 2 つ並んでいた問題を修正。

### 変更
- 先頭の空 \`## 2026.3.2-yami-1.9.38\` 見出しを削除
- 代わりに \`## Unreleased\` を復元（次回リリース時の自動 bump 起点）

### 背景
PR #293 マージ後、staging 上で github-actions[bot] が \`## Unreleased\` → \`## 2026.3.2-yami-1.9.38\` に bump したが、develop 側で既に \`## 2026.3.2-yami-1.9.38\` セクションを明示的に書いていたため同名見出しが重複した。

### 影響範囲
- GitHub Release \`2026.3.2-yami-1.9.38\` は既に発行済みで影響なし
- Tag 発行済みで影響なし
- DIFFERENCE.md の見た目のみ修正

### 次のステップ
本 PR マージ後、\`staging → master\` の hotfix PR を別途作成して同じ修正を master にも適用する。