### PR TITLE
docs(DIFFERENCE): dedup 1.9.38 heading and restore Unreleased

### DIFF
--- a/DIFFERENCE.md
+++ b/DIFFERENCE.md
@@ -1,6 +1,6 @@
 # DIFFRENCE
 
-## 2026.3.2-yami-1.9.38
+## Unreleased
 
 ## 2026.3.2-yami-1.9.38
 


### PR DESCRIPTION
## Summary
PR #295 と同じ修正を master にも反映する hotfix。

- 先頭の空 \`## 2026.3.2-yami-1.9.38\` 見出しを削除
- 代わりに \`## Unreleased\` を復元

### 背景
Release Manager の自動 bump と develop 側の明示見出しが衝突し、staging / master の DIFFERENCE.md に \`## 2026.3.2-yami-1.9.38\` が 2 つ並んでいた。staging 側は PR #295 で修正済。

### リリース影響
- GitHub Release \`2026.3.2-yami-1.9.38\` は既に発行済みで影響なし
- Tag 発行済みで影響なし
- DIFFERENCE.md の見た目のみ修正

タイトルは "Release:" 形式ではなく "docs:" 形式としており、\`release-on-merge.yml\` の GitHub Release 作成トリガー条件（タイトル \`Release:\` 含有）に引っかからないため、新しい Release は作成されない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースドキュメントのバージョン見出しを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->