### PR TITLE
ci(claude): モデルを claude-opus-4-8 に pin し API テスト workflow を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-opus-4-8"
           allowed_bots: "release-manager-actions,dependabot,renovate"
           prompt: |
             Please review this pull request and provide feedback on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: "claude-opus-4-8"
           allowed_bots: "release-manager-actions"
           additional_permissions: |
             actions: read

--- a/.github/workflows/test-claude-api.yml
+++ b/.github/workflows/test-claude-api.yml
@@ -27,8 +27,7 @@ jobs:
         run: |
           echo "Testing Claude API with new key..."
           echo "API Key available: ${ANTHROPIC_API_KEY:+YES}"
-          echo "API Key prefix: ${ANTHROPIC_API_KEY:0:20}..."
-          
+
           # シンプルなテストメッセージ
           TEST_PROMPT="${TEST_MESSAGE:-Hello Claude, please respond with a simple greeting in Japanese.}"
           
@@ -38,7 +37,7 @@ jobs:
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \
             -d "{
-              \"model\": \"claude-3-5-sonnet-20241022\",
+              \"model\": \"claude-opus-4-8\",
               \"max_tokens\": 100,
               \"messages\": [
                 {


### PR DESCRIPTION
## 背景
Claude 自動レビュー (claude-code-review.yml) が **0 コメント**になる問題を調査した結果、2つの原因が判明：

1. **`ANTHROPIC_API_KEY` が無効**（401 invalid x-api-key）→ Secret 更新済み（テストで 401→404 を確認、認証通過）
2. **`claude-code-action@v1` がデフォルトで内部エイリアス `claude-opus-4-8[1m]` を使用** → API が invalid model identifier として弾く既知バグ（[anthropics/claude-code#68005](https://github.com/anthropics/claude-code/issues/68005)、Opus 4.6/4.7 でも繰り返し報告）

## 変更
- `claude-code-review.yml` / `claude.yml`: `model: claude-opus-4-8` を明示 pin（`[1m]` バグ回避）
- `test-claude-api.yml`: 廃止モデル `claude-3-5-sonnet-20241022`（2025-10-28 廃止）→ `claude-opus-4-8` に更新、API キー先頭を出力していた行を削除

## 検証
この PR 自体が `claude-code-review.yml` をトリガーするため、**キー更新＋モデル pin 後に自動レビューが実際にコメントを出すか**をこの PR でライブ確認できる。